### PR TITLE
Checking error of currently compiled bytes

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,7 +66,7 @@ func Load(configFilePath string, schema, defaults []byte, runtime any, dest any)
 	}
 	// Compile the defaults.
 	defaultsVal := ctx.CompileBytes(defaults, cue.Filename("$defaults.cue"))
-	if err := schemaVal.Err(); err != nil {
+	if err := defaultsVal.Err(); err != nil {
 		return fmt.Errorf("unexpected error in defaults %q: %v", defaults, errors.Details(err, nil))
 	}
 


### PR DESCRIPTION
Checking the error returned in defaultVal rather than previously checked schemaVal.

The test passes either way, as the values are correct, however I would assume we are interested in checking defaultVal and not schemaVal in this case? I do still not have a good grasp on cue, so not 100% sure.